### PR TITLE
Add FRA1 scheduled maintenance notice — April 2026

### DIFF
--- a/content/issues/2026-04-06-planned_maintenance_in_FRA1.md
+++ b/content/issues/2026-04-06-planned_maintenance_in_FRA1.md
@@ -1,0 +1,19 @@
+---
+title: Planned Maintenance in FRA1
+date: 2026-04-06 00:00:01
+resolved: false
+resolvedWhen:
+severity: notice
+affected:
+  - Compute/FRA1
+  - Storage/FRA1
+  - Network/FRA1
+section: issue
+
+---
+We will be performing scheduled maintenance in the FRA1 region starting the week of 6 April 2026, with a duration of approximately two weeks.
+
+Compute instances and Kubernetes nodes will be live migrated with no expected downtime. A small number of other services may experience brief interruptions of a few seconds as they are restarted.
+
+No action is required on your part. We will continue to monitor the situation closely and provide updates as maintenance progresses.
+---


### PR DESCRIPTION
Two-week maintenance window starting 6 April for compute node upgrades in FRA1. VMs and k8s nodes live migrated, brief interruptions possible for some services.