### PR TITLE
Add continuing investigation update to FRA1 incident

### DIFF
--- a/content/issues/2026-06-30-FRA1-storage-compute-instability.md
+++ b/content/issues/2026-06-30-FRA1-storage-compute-instability.md
@@ -11,6 +11,12 @@ section: issue
 
 ---
 
+2026-06-30 11:30 UTC
+
+We continue to investigate the storage and compute instability in the FRA1 region.
+
+---
+
 2026-06-30 10:45 UTC
 
 We are investigating storage and compute instability in the FRA1 region. Some customer instances and volumes may be experiencing degraded performance or be unavailable. Our engineering team is actively investigating the cause and we will provide further updates as more information becomes available.

--- a/content/issues/2026-06-30-FRA1-storage-compute-instability.md
+++ b/content/issues/2026-06-30-FRA1-storage-compute-instability.md
@@ -1,6 +1,6 @@
 ---
 title: Storage and compute instability in FRA1
-date: 2026-06-30 10:45:00
+date: 2026-06-30 09:45:00
 resolved: false
 # Possible severity levels: down, disrupted, notice
 severity: disrupted
@@ -11,12 +11,12 @@ section: issue
 
 ---
 
-2026-06-30 11:30 UTC
+2026-06-30 10:30 UTC
 
 We continue to investigate the storage and compute instability in the FRA1 region.
 
 ---
 
-2026-06-30 10:45 UTC
+2026-06-30 09:45 UTC
 
 We are investigating storage and compute instability in the FRA1 region. Some customer instances and volumes may be experiencing degraded performance or be unavailable. Our engineering team is actively investigating the cause and we will provide further updates as more information becomes available.


### PR DESCRIPTION
## Summary

Adds an 11:30 UTC update to the ongoing FRA1 storage and compute instability incident.

> We continue to investigate the storage and compute instability in the FRA1 region.

Incident remains `resolved: false`.