### PR TITLE
Downgrade FRA1 incident to monitoring

### DIFF
--- a/content/issues/2026-06-30-FRA1-storage-compute-instability.md
+++ b/content/issues/2026-06-30-FRA1-storage-compute-instability.md
@@ -3,11 +3,17 @@ title: Storage and compute instability in FRA1
 date: 2026-06-30 09:45:00
 resolved: false
 # Possible severity levels: down, disrupted, notice
-severity: disrupted
+severity: monitoring
 affected:
   - Storage/FRA1
   - Compute/FRA1
 section: issue
+
+---
+
+2026-06-30 11:15 UTC
+
+We have applied a fix and storage and compute services in the FRA1 region have recovered. We are now monitoring to confirm the issue is fully resolved.
 
 ---
 


### PR DESCRIPTION
## Summary

Storage and compute in FRA1 have recovered after a fix. Downgrades the incident from `disrupted` to `monitoring` and adds an 11:15 UTC recovery update. Kept `resolved: false` while we confirm the fix holds.