### PR TITLE
Resolve FRA1 storage and compute instability incident

### DIFF
--- a/content/issues/2026-06-30-FRA1-storage-compute-instability.md
+++ b/content/issues/2026-06-30-FRA1-storage-compute-instability.md
@@ -1,13 +1,20 @@
 ---
 title: Storage and compute instability in FRA1
 date: 2026-06-30 09:45:00
-resolved: false
+resolved: true
+resolvedWhen: 2026-06-30 14:22:00
 # Possible severity levels: down, disrupted, notice
 severity: monitoring
 affected:
   - Storage/FRA1
   - Compute/FRA1
 section: issue
+
+---
+
+2026-06-30 14:22 UTC
+
+This incident is now resolved. Storage and compute services in the FRA1 region are operating normally.
 
 ---
 


### PR DESCRIPTION
## Summary

Marks the FRA1 storage and compute instability incident as resolved.

- `resolved: true` with `resolvedWhen: 2026-06-30 14:22:00`
- Adds a final 14:22 UTC resolved update at the top of the body
- Severity left at `monitoring` (consistent with prior FRA1 incident at resolution)