### PR TITLE
Add CVE-2026-53359 KVM security maintenance notices (per region)

### DIFF
--- a/content/issues/2026-07-09-security-maintenance-cve-2026-53359-fra1.md
+++ b/content/issues/2026-07-09-security-maintenance-cve-2026-53359-fra1.md
@@ -8,7 +8,7 @@ affected:
 section: issue
 
 ---
-We are addressing a recently disclosed Linux KVM security vulnerability, CVE-2026-53359, which may affect certain virtualised environments.
+We are addressing a recently disclosed zero-day Linux KVM security vulnerability, CVE-2026-53359, which may affect certain virtualised environments.
 
 Mitigations have been rolled out across all regions, and all newly created instances are unaffected and require no further action.
 

--- a/content/issues/2026-07-09-security-maintenance-cve-2026-53359-fra1.md
+++ b/content/issues/2026-07-09-security-maintenance-cve-2026-53359-fra1.md
@@ -1,0 +1,32 @@
+---
+title: Security Maintenance – CVE-2026-53359 (KVM VM Escape) in FRA1
+date: 2026-07-09 12:00:00
+resolved: false
+severity: notice
+affected:
+  - Compute/FRA1
+section: issue
+
+---
+We are addressing a recently disclosed Linux KVM security vulnerability, CVE-2026-53359, which may affect certain virtualised environments.
+
+Mitigations have been rolled out across all regions, and all newly created instances are unaffected and require no further action.
+
+**Action required**
+
+Existing instances must be powered off and back on to complete the update. Please do this via the Civo Dashboard (using the **Reboot** option) or via the CLI using `civo instance reboot`. Do **not** use `civo instance soft-reboot`, and do **not** reboot from within the operating system itself, as these will not apply the fix correctly.
+
+As part of this security fix, **nested virtualisation will be disabled**. If your workloads rely on nested virtualisation, please be aware that this functionality will no longer be available following your next VM restart.
+
+You can power off and restart at a time convenient to you ahead of the scheduled maintenance window below. If your instance has not been restarted beforehand, Civo will complete this during the window:
+
+**FRA1 (Frankfurt, CEST)** — Thu 9th Jul 21:00 – Fri 10th Jul 06:00 CEST (Thu 9th Jul 19:00 – Fri 10th Jul 04:00 UTC)
+
+During the maintenance window, your instance will experience a brief period of downtime. No data loss is expected.
+
+**Private / dedicated infrastructure customers**
+
+If you are on private infrastructure, our team will contact you directly to coordinate a suitable maintenance window based on your operational requirements.
+
+If you have any questions or require assistance, please reach out to our Support team.
+---

--- a/content/issues/2026-07-09-security-maintenance-cve-2026-53359-fra1.md
+++ b/content/issues/2026-07-09-security-maintenance-cve-2026-53359-fra1.md
@@ -1,6 +1,6 @@
 ---
 title: Security Maintenance – CVE-2026-53359 (KVM VM Escape) in FRA1
-date: 2026-07-09 12:00:00
+date: 2026-07-09 19:00:00
 resolved: false
 severity: notice
 affected:

--- a/content/issues/2026-07-09-security-maintenance-cve-2026-53359-lon1.md
+++ b/content/issues/2026-07-09-security-maintenance-cve-2026-53359-lon1.md
@@ -1,6 +1,6 @@
 ---
 title: Security Maintenance – CVE-2026-53359 (KVM VM Escape) in LON1
-date: 2026-07-09 12:00:00
+date: 2026-07-09 20:00:00
 resolved: false
 severity: notice
 affected:

--- a/content/issues/2026-07-09-security-maintenance-cve-2026-53359-lon1.md
+++ b/content/issues/2026-07-09-security-maintenance-cve-2026-53359-lon1.md
@@ -8,7 +8,7 @@ affected:
 section: issue
 
 ---
-We are addressing a recently disclosed Linux KVM security vulnerability, CVE-2026-53359, which may affect certain virtualised environments.
+We are addressing a recently disclosed zero-day Linux KVM security vulnerability, CVE-2026-53359, which may affect certain virtualised environments.
 
 Mitigations have been rolled out across all regions, and all newly created instances are unaffected and require no further action.
 

--- a/content/issues/2026-07-09-security-maintenance-cve-2026-53359-lon1.md
+++ b/content/issues/2026-07-09-security-maintenance-cve-2026-53359-lon1.md
@@ -1,0 +1,32 @@
+---
+title: Security Maintenance – CVE-2026-53359 (KVM VM Escape) in LON1
+date: 2026-07-09 12:00:00
+resolved: false
+severity: notice
+affected:
+  - Compute/LON1
+section: issue
+
+---
+We are addressing a recently disclosed Linux KVM security vulnerability, CVE-2026-53359, which may affect certain virtualised environments.
+
+Mitigations have been rolled out across all regions, and all newly created instances are unaffected and require no further action.
+
+**Action required**
+
+Existing instances must be powered off and back on to complete the update. Please do this via the Civo Dashboard (using the **Reboot** option) or via the CLI using `civo instance reboot`. Do **not** use `civo instance soft-reboot`, and do **not** reboot from within the operating system itself, as these will not apply the fix correctly.
+
+As part of this security fix, **nested virtualisation will be disabled**. If your workloads rely on nested virtualisation, please be aware that this functionality will no longer be available following your next VM restart.
+
+You can power off and restart at a time convenient to you ahead of the scheduled maintenance window below. If your instance has not been restarted beforehand, Civo will complete this during the window:
+
+**LON1 (London, BST)** — Thu 9th Jul 21:00 – Fri 10th Jul 06:00 BST (Thu 9th Jul 20:00 – Fri 10th Jul 05:00 UTC)
+
+During the maintenance window, your instance will experience a brief period of downtime. No data loss is expected.
+
+**Private / dedicated infrastructure customers**
+
+If you are on private infrastructure, our team will contact you directly to coordinate a suitable maintenance window based on your operational requirements.
+
+If you have any questions or require assistance, please reach out to our Support team.
+---

--- a/content/issues/2026-07-09-security-maintenance-cve-2026-53359-mum1.md
+++ b/content/issues/2026-07-09-security-maintenance-cve-2026-53359-mum1.md
@@ -8,7 +8,7 @@ affected:
 section: issue
 
 ---
-We are addressing a recently disclosed Linux KVM security vulnerability, CVE-2026-53359, which may affect certain virtualised environments.
+We are addressing a recently disclosed zero-day Linux KVM security vulnerability, CVE-2026-53359, which may affect certain virtualised environments.
 
 Mitigations have been rolled out across all regions, and all newly created instances are unaffected and require no further action.
 

--- a/content/issues/2026-07-09-security-maintenance-cve-2026-53359-mum1.md
+++ b/content/issues/2026-07-09-security-maintenance-cve-2026-53359-mum1.md
@@ -1,6 +1,6 @@
 ---
 title: Security Maintenance – CVE-2026-53359 (KVM VM Escape) in MUM1
-date: 2026-07-09 12:00:00
+date: 2026-07-10 15:30:00
 resolved: false
 severity: notice
 affected:

--- a/content/issues/2026-07-09-security-maintenance-cve-2026-53359-mum1.md
+++ b/content/issues/2026-07-09-security-maintenance-cve-2026-53359-mum1.md
@@ -1,0 +1,32 @@
+---
+title: Security Maintenance – CVE-2026-53359 (KVM VM Escape) in MUM1
+date: 2026-07-09 12:00:00
+resolved: false
+severity: notice
+affected:
+  - Compute/MUM1
+section: issue
+
+---
+We are addressing a recently disclosed Linux KVM security vulnerability, CVE-2026-53359, which may affect certain virtualised environments.
+
+Mitigations have been rolled out across all regions, and all newly created instances are unaffected and require no further action.
+
+**Action required**
+
+Existing instances must be powered off and back on to complete the update. Please do this via the Civo Dashboard (using the **Reboot** option) or via the CLI using `civo instance reboot`. Do **not** use `civo instance soft-reboot`, and do **not** reboot from within the operating system itself, as these will not apply the fix correctly.
+
+As part of this security fix, **nested virtualisation will be disabled**. If your workloads rely on nested virtualisation, please be aware that this functionality will no longer be available following your next VM restart.
+
+You can power off and restart at a time convenient to you ahead of the scheduled maintenance window below. If your instance has not been restarted beforehand, Civo will complete this during the window:
+
+**MUM1 (Mumbai, IST)** — Fri 10th Jul 21:00 – Sat 11th Jul 06:00 IST (Fri 10th Jul 15:30 – Sat 11th Jul 00:30 UTC)
+
+During the maintenance window, your instance will experience a brief period of downtime. No data loss is expected.
+
+**Private / dedicated infrastructure customers**
+
+If you are on private infrastructure, our team will contact you directly to coordinate a suitable maintenance window based on your operational requirements.
+
+If you have any questions or require assistance, please reach out to our Support team.
+---

--- a/content/issues/2026-07-09-security-maintenance-cve-2026-53359-nyc1.md
+++ b/content/issues/2026-07-09-security-maintenance-cve-2026-53359-nyc1.md
@@ -8,7 +8,7 @@ affected:
 section: issue
 
 ---
-We are addressing a recently disclosed Linux KVM security vulnerability, CVE-2026-53359, which may affect certain virtualised environments.
+We are addressing a recently disclosed zero-day Linux KVM security vulnerability, CVE-2026-53359, which may affect certain virtualised environments.
 
 Mitigations have been rolled out across all regions, and all newly created instances are unaffected and require no further action.
 

--- a/content/issues/2026-07-09-security-maintenance-cve-2026-53359-nyc1.md
+++ b/content/issues/2026-07-09-security-maintenance-cve-2026-53359-nyc1.md
@@ -1,6 +1,6 @@
 ---
 title: Security Maintenance – CVE-2026-53359 (KVM VM Escape) in NYC1
-date: 2026-07-09 12:00:00
+date: 2026-07-10 01:00:00
 resolved: false
 severity: notice
 affected:

--- a/content/issues/2026-07-09-security-maintenance-cve-2026-53359-nyc1.md
+++ b/content/issues/2026-07-09-security-maintenance-cve-2026-53359-nyc1.md
@@ -1,0 +1,32 @@
+---
+title: Security Maintenance – CVE-2026-53359 (KVM VM Escape) in NYC1
+date: 2026-07-09 12:00:00
+resolved: false
+severity: notice
+affected:
+  - Compute/NYC1
+section: issue
+
+---
+We are addressing a recently disclosed Linux KVM security vulnerability, CVE-2026-53359, which may affect certain virtualised environments.
+
+Mitigations have been rolled out across all regions, and all newly created instances are unaffected and require no further action.
+
+**Action required**
+
+Existing instances must be powered off and back on to complete the update. Please do this via the Civo Dashboard (using the **Reboot** option) or via the CLI using `civo instance reboot`. Do **not** use `civo instance soft-reboot`, and do **not** reboot from within the operating system itself, as these will not apply the fix correctly.
+
+As part of this security fix, **nested virtualisation will be disabled**. If your workloads rely on nested virtualisation, please be aware that this functionality will no longer be available following your next VM restart.
+
+You can power off and restart at a time convenient to you ahead of the scheduled maintenance window below. If your instance has not been restarted beforehand, Civo will complete this during the window:
+
+**NYC1 (New York, EDT)** — Thu 9th Jul 21:00 – Fri 10th Jul 06:00 EDT (Fri 10th Jul 01:00 – Fri 10th Jul 10:00 UTC)
+
+During the maintenance window, your instance will experience a brief period of downtime. No data loss is expected.
+
+**Private / dedicated infrastructure customers**
+
+If you are on private infrastructure, our team will contact you directly to coordinate a suitable maintenance window based on your operational requirements.
+
+If you have any questions or require assistance, please reach out to our Support team.
+---

--- a/content/issues/2026-07-09-security-maintenance-cve-2026-53359-phx1.md
+++ b/content/issues/2026-07-09-security-maintenance-cve-2026-53359-phx1.md
@@ -8,7 +8,7 @@ affected:
 section: issue
 
 ---
-We are addressing a recently disclosed Linux KVM security vulnerability, CVE-2026-53359, which may affect certain virtualised environments.
+We are addressing a recently disclosed zero-day Linux KVM security vulnerability, CVE-2026-53359, which may affect certain virtualised environments.
 
 Mitigations have been rolled out across all regions, and all newly created instances are unaffected and require no further action.
 

--- a/content/issues/2026-07-09-security-maintenance-cve-2026-53359-phx1.md
+++ b/content/issues/2026-07-09-security-maintenance-cve-2026-53359-phx1.md
@@ -1,6 +1,6 @@
 ---
 title: Security Maintenance – CVE-2026-53359 (KVM VM Escape) in PHX1
-date: 2026-07-09 12:00:00
+date: 2026-07-10 04:00:00
 resolved: false
 severity: notice
 affected:

--- a/content/issues/2026-07-09-security-maintenance-cve-2026-53359-phx1.md
+++ b/content/issues/2026-07-09-security-maintenance-cve-2026-53359-phx1.md
@@ -1,0 +1,32 @@
+---
+title: Security Maintenance – CVE-2026-53359 (KVM VM Escape) in PHX1
+date: 2026-07-09 12:00:00
+resolved: false
+severity: notice
+affected:
+  - Compute/PHX1
+section: issue
+
+---
+We are addressing a recently disclosed Linux KVM security vulnerability, CVE-2026-53359, which may affect certain virtualised environments.
+
+Mitigations have been rolled out across all regions, and all newly created instances are unaffected and require no further action.
+
+**Action required**
+
+Existing instances must be powered off and back on to complete the update. Please do this via the Civo Dashboard (using the **Reboot** option) or via the CLI using `civo instance reboot`. Do **not** use `civo instance soft-reboot`, and do **not** reboot from within the operating system itself, as these will not apply the fix correctly.
+
+As part of this security fix, **nested virtualisation will be disabled**. If your workloads rely on nested virtualisation, please be aware that this functionality will no longer be available following your next VM restart.
+
+You can power off and restart at a time convenient to you ahead of the scheduled maintenance window below. If your instance has not been restarted beforehand, Civo will complete this during the window:
+
+**PHX1 (Phoenix, MST)** — Thu 9th Jul 21:00 – Fri 10th Jul 06:00 MST (Fri 10th Jul 04:00 – Fri 10th Jul 13:00 UTC)
+
+During the maintenance window, your instance will experience a brief period of downtime. No data loss is expected.
+
+**Private / dedicated infrastructure customers**
+
+If you are on private infrastructure, our team will contact you directly to coordinate a suitable maintenance window based on your operational requirements.
+
+If you have any questions or require assistance, please reach out to our Support team.
+---


### PR DESCRIPTION
## Summary

Adds status page notices for the **CVE-2026-53359** KVM VM escape security maintenance, one per affected region: LON1, NYC1, MUM1, FRA1 and PHX1.

Splitting into per-region notices (rather than one combined notice) means each can be flipped to `resolved: true` independently as that region's maintenance window completes.

Each notice covers:
- Required customer action — power off/on via the Dashboard **Reboot** option or `civo instance reboot` (explicitly not `soft-reboot` and not an OS-level reboot)
- Nested virtualisation being disabled as part of the fix
- The region-specific maintenance window (local + UTC)
- Guidance for private / dedicated infrastructure customers

## Maintenance windows

| Region | Local | UTC |
|---|---|---|
| LON1 | Thu 9th Jul 21:00 – Fri 10th Jul 06:00 BST | Thu 20:00 – Fri 05:00 |
| NYC1 | Thu 9th Jul 21:00 – Fri 10th Jul 06:00 EDT | Fri 01:00 – Fri 10:00 |
| MUM1 | Fri 10th Jul 21:00 – Sat 11th Jul 06:00 IST | Fri 15:30 – Sat 00:30 |
| FRA1 | Thu 9th Jul 21:00 – Fri 10th Jul 06:00 CEST | Thu 19:00 – Fri 04:00 |
| PHX1 | Thu 9th Jul 21:00 – Fri 10th Jul 06:00 MST | Fri 04:00 – Fri 13:00 |

## Notes

Each notice is `resolved: false` / `severity: notice`. As each region's window closes, set `resolved: true`, add `resolvedWhen:`, and add a wrap-up line above the top separator (following the existing PHX1/FRA1 emergency-maintenance pattern).