### PR TITLE
Fix incorrect resolution date on FRA1 disruption incident

### DIFF
--- a/content/issues/2026-02-24-FRA1-disruption.md
+++ b/content/issues/2026-02-24-FRA1-disruption.md
@@ -2,7 +2,7 @@
 title: Service disruption in FRA1
 date: 2026-02-24 15:12:00
 resolved: true
-resolvedWhen: 2026-03-25 10:00:00
+resolvedWhen: 2026-02-26 10:00:00
 severity: monitoring
 affected:
   - Compute/FRA1
@@ -10,7 +10,7 @@ affected:
 section: issue
 
 ---
-2026-03-25 10:00:00 UTC
+2026-02-26 10:00:00 UTC
 
 This incident is now resolved. The root causes have been identified and fixes have been deployed to the FRA1 region. All services are operating normally and we continue to monitor.
 


### PR DESCRIPTION
## Summary
- `resolvedWhen` on the 2026-02-24 FRA1 disruption was recorded as `2026-03-25 10:00:00`, a month after the incident's last monitoring update (`2026-02-25 15:41:00`, "all services are online").
- The closing commit (#48) was made exactly one month later and used that day's date rather than backdating to when the incident actually resolved.
- Confirmed this should have closed the next day: corrected to `2026-02-26 10:00:00`.

## Test plan
- [x] Frontmatter `resolvedWhen` updated
- [x] Body timestamp header updated to match