### PR TITLE
LON1: update - team working on a resolution

### DIFF
--- a/content/issues/2026-07-28-lon1-storage-network-degraded-performance.md
+++ b/content/issues/2026-07-28-lon1-storage-network-degraded-performance.md
@@ -11,6 +11,12 @@ section: issue
 
 ---
 
+2026-07-28 12:00 UTC
+
+Our engineering team is continuing to work on a resolution for the degraded storage and network performance in the London (LON1) region. Customers may continue to experience increased latency or reduced throughput in this region in the meantime. We will provide a further update as soon as we have more information.
+
+---
+
 2026-07-28 10:55 UTC
 
 We are investigating reports of degraded storage and network performance in the London (LON1) region. Customers may experience increased latency or reduced throughput when accessing volumes and network services in this region. Our engineering team is actively investigating and we will provide further updates as more information becomes available.


### PR DESCRIPTION
Adds a 12:00 UTC update to the open LON1 degraded storage/network incident.

- Still unresolved (`resolved: false`)
- Severity unchanged (`disrupted`)
- Team working on a resolution; next update when more info is available