### PR TITLE
LON1: mark degraded storage/network incident resolved

### DIFF
--- a/content/issues/2026-07-28-lon1-storage-network-degraded-performance.md
+++ b/content/issues/2026-07-28-lon1-storage-network-degraded-performance.md
@@ -1,13 +1,20 @@
 ---
 title: Degraded storage and network performance in LON1
 date: 2026-07-28 10:55:00
-resolved: false
+resolved: true
+resolvedWhen: 2026-07-29 07:00:00
 # Possible severity levels: down, disrupted, notice
 severity: disrupted
 affected:
   - Storage/LON1
   - Network/LON1
 section: issue
+
+---
+
+2026-07-29 07:00 UTC
+
+Storage and network performance in the London (LON1) region has returned to normal levels and the fix has held under monitoring. This incident is now resolved. Thank you for your patience.
 
 ---
 


### PR DESCRIPTION
Closes out the LON1 degraded storage/network incident.

- `resolved: true`, `resolvedWhen: 2026-07-29 07:00:00`
- Adds a resolution update at the top of the timeline

Note: the resolution time is recorded as **07:00 UTC** on 2026-07-29, matching the UTC convention used throughout the status page. If 7am was local (BST), this should be 06:00 UTC instead.