### PR TITLE
PHX1: update - partner DC working with vendors, no ETA

### DIFF
--- a/content/issues/2026-08-13-phx1-datacentre-cooling-issues.md
+++ b/content/issues/2026-08-13-phx1-datacentre-cooling-issues.md
@@ -12,6 +12,12 @@ section: issue
 
 ---
 
+2026-08-13 13:36 UTC
+
+Our data centre partner is working with their vendors to resolve the cooling issues at the Phoenix facility, but is unable to provide an ETA at this time. We continue to monitor the situation closely and will post further updates as more information becomes available.
+
+---
+
 2026-08-13 12:56 UTC
 
 Our data centre partner in the Phoenix (PHX1) region has reported cooling issues at their facility. API calls to the PHX1 region may be affected and tenant workloads in this region are at risk while the issue persists. Our data centre partner's own status page for this incident is available at <https://status.phoenixnap.com/incidents/dnjp5pfv2mmh>. We are monitoring the situation closely and will provide further updates as more information becomes available.


### PR DESCRIPTION
Adds an update to the PHX1 cooling incident: the data centre partner is working with their vendors to resolve the cooling issues but is unable to provide an ETA at this time.